### PR TITLE
Use set instead of put

### DIFF
--- a/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
+++ b/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
@@ -197,7 +197,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
 
     jobsByKey.lock(newJobKey, 5, TimeUnit.SECONDS);
     try {
-      jobsByKey.put(newJobKey, newJob);
+      jobsByKey.set(newJobKey, newJob);
       jobsByGroup.put(newJobKey.getGroup(), newJobKey);
     } finally {
       try {
@@ -318,7 +318,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
           : NORMAL;
 
       final TriggerWrapper newTriger = newTriggerWrapper(newTrigger, state);
-      triggersByKey.put(newTriger.key, newTriger);
+      triggersByKey.set(newTriger.key, newTriger);
       triggers.add(newTriger);
       triggersByGroup.put(triggerKey.getGroup(), triggerKey);
     } finally {
@@ -407,7 +407,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
       throw new ObjectAlreadyExistsException("Calendar with name '" + calName
           + "' already exists.");
     } else {
-      calendarsByName.put(calName, calendar);
+      calendarsByName.set(calName, calendar);
     }
   }
 
@@ -583,7 +583,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
     try {
       final TriggerWrapper newTrigger = newTriggerWrapper(
           triggersByKey.get(triggerKey), PAUSED);
-      triggersByKey.put(triggerKey, newTrigger);
+      triggersByKey.set(triggerKey, newTrigger);
     } finally {
       try {
         triggersByKey.unlock(triggerKey);
@@ -622,7 +622,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
     try {
       if (schedulerRunning) {
         final TriggerWrapper newTrigger = newTriggerWrapper(triggersByKey.get(triggerKey), NORMAL);
-        triggersByKey.put(newTrigger.key, newTrigger);
+        triggersByKey.set(newTrigger.key, newTrigger);
       }
     } finally {
       try {
@@ -1016,7 +1016,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
       JobKey jobKey = jobDetail.getKey();
       jobsByKey.lock(jobKey, 5, TimeUnit.SECONDS);
       try {
-        jobsByKey.put(jobKey, jobDetail);
+        jobsByKey.set(jobKey, jobDetail);
         jobsByGroup.put(jobKey.getGroup(), jobKey);
       } finally {
         try {
@@ -1140,7 +1140,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
     if (tw.getState() == NORMAL || tw.getState() == WAITING) {
       triggers.add(tw);
     }
-    triggersByKey.put(tw.key, tw);
+    triggersByKey.set(tw.key, tw);
   }
 
 }


### PR DESCRIPTION
According to Hazelcast documentation, ```set``` is more efficient than ```put``` because it does not have to fetch the old value before setting the new value.