### PR TITLE
Skip hazelcast client shutdown

### DIFF
--- a/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
+++ b/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
@@ -97,6 +97,7 @@ public class HazelcastJobStore implements JobStore, Serializable {
 
   private String instanceId;
   private String instanceName;
+  private boolean shutdownHazelcastOnShutdown = true;
 
   public static final DateTimeFormatter FORMATTER = ISODateTimeFormat.basicDateTimeNoMillis();
 
@@ -153,7 +154,9 @@ public class HazelcastJobStore implements JobStore, Serializable {
   @Override
   public void shutdown() {
     
-    hazelcastClient.shutdown();
+    if (shutdownHazelcastOnShutdown) {
+      hazelcastClient.shutdown();
+    }
   }
 
   @Override

--- a/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
+++ b/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
@@ -1043,6 +1043,11 @@ public class HazelcastJobStore implements JobStore, Serializable {
     this.instanceId = instanceId;
   }
 
+  public void setShutdownHazelcastOnShutdown(boolean shutdownHazelcastOnShutdown) {
+
+    this.shutdownHazelcastOnShutdown = shutdownHazelcastOnShutdown;
+  }
+
   @Override
   public void setThreadPoolSize(int poolSize) {
 

--- a/src/test/java/com/bikeemotion/quartz/AbstractTest.java
+++ b/src/test/java/com/bikeemotion/quartz/AbstractTest.java
@@ -1,5 +1,7 @@
 package com.bikeemotion.quartz;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import java.util.Date;
 import org.joda.time.DateTime;
@@ -23,6 +25,13 @@ public abstract class AbstractTest {
   protected JobStore jobStore;
   protected int buildTriggerIndex = 0;
   protected int buildJobIndex = 0;
+
+  protected HazelcastInstance createHazelcastInstance() {
+
+    Config config = new Config();
+    config.setProperty("hazelcast.logging.type", "slf4j");
+    return Hazelcast.newHazelcastInstance(config);
+  }
 
   protected JobDetail buildJob() {
 

--- a/src/test/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStoreTest.java
+++ b/src/test/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStoreTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Lists;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -20,7 +19,6 @@ import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.JobPersistenceException;
 import org.quartz.ObjectAlreadyExistsException;
-
 import static org.quartz.Scheduler.DEFAULT_GROUP;
 import org.quartz.SchedulerException;
 import org.quartz.SimpleScheduleBuilder;
@@ -45,7 +43,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;


### PR DESCRIPTION
```java
// Setting Hazelcast Job Store
Properties props = new Properties();
props.setProperty(StdSchedulerFactory.PROP_JOB_STORE_CLASS, HazelcastJobStore.class.getName());
props.setProperty(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".shutdownHazelcastOnShutdown", "false");
```

We need this, because we use the Hazelcast instance for other things, and we don't want it to shut down when Quartz does.