### PR TITLE
Fixed concurrentExecutionDisallowed jobs

### DIFF
--- a/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/TriggerState.java
+++ b/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/TriggerState.java
@@ -7,6 +7,7 @@ public enum TriggerState {
   COMPLETE,
   ERROR,
   BLOCKED,
+  PAUSED_BLOCKED,
   ACQUIRED,
   WAITING,
   STATE_COMPLETED;
@@ -22,6 +23,7 @@ public enum TriggerState {
     case ERROR:
       return org.quartz.Trigger.TriggerState.ERROR;
     case BLOCKED:
+    case PAUSED_BLOCKED:
       return org.quartz.Trigger.TriggerState.BLOCKED;
     case NORMAL:
     case ACQUIRED:

--- a/src/test/java/com/bikeemotion/quartz/MyNoConcurrentJob.java
+++ b/src/test/java/com/bikeemotion/quartz/MyNoConcurrentJob.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) Bikeemotion
+ * 2014
+ *
+ * The reproduction, transmission or use of this document or its contents is not
+ * permitted without express written authorization. All rights, including rights
+ * created by patent grant or registration of a utility model or design, are
+ * reserved. Modifications made to this document are restricted to authorized
+ * personnel only. Technical specifications and features are binding only when
+ * specifically and expressly agreed upon in a written contract.
+ */
+package com.bikeemotion.quartz;
+
+import org.quartz.DisallowConcurrentExecution;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@DisallowConcurrentExecution
+public final class MyNoConcurrentJob implements Job, Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MyNoConcurrentJob.class);
+
+  public static int count = 0;
+  public static Queue<String> jobKeys = new LinkedList<>();
+  public static Queue<String> triggerKeys = new LinkedList<>();
+  public static long waitTime = 300;
+
+  @Override
+  public void execute(final JobExecutionContext jobCtx)
+    throws JobExecutionException {
+
+    jobKeys.add(jobCtx.getJobDetail().getKey().getName());
+    triggerKeys.add(jobCtx.getTrigger().getKey().getName());
+    count++;
+    LOG.info("Processing Trigger " + jobCtx.getTrigger().getKey().getName() + " " + new Date());
+     try {
+      Thread.sleep(waitTime);
+    } catch (InterruptedException ex) {
+    }
+     LOG.info("All job done");
+  }
+
+}

--- a/src/test/java/com/bikeemotion/quartz/QuartzTest.java
+++ b/src/test/java/com/bikeemotion/quartz/QuartzTest.java
@@ -240,7 +240,7 @@ public class QuartzTest extends AbstractTest {
     MyNoConcurrentJob.waitTime = 300;
 
     scheduler.scheduleJob(job1, o);
-    Thread.sleep(750);
+    Thread.sleep(850);
 
     // since MyNoCocurrent job takes 300 ms to finish
     assertEquals(MyNoConcurrentJob.count, 3);


### PR DESCRIPTION
Fixed concurrentExecutionDisallowed jobs (#35), since they were never released after being acquired.

From @anton-johansson sample here is the output after this PR:

<pre>
2016-08-18 18:36:20.927 INFO  StdSchedulerFactory:1339 - Quartz scheduler 'AntonJohanssonSchedulerInstance' initialized from an externally provided properties instance.
2016-08-18 18:36:20.927 INFO  StdSchedulerFactory:1343 - Quartz scheduler version: 2.2.1
2016-08-18 18:36:20.928 INFO  HazelcastJobStore:137 - Hazelcast Job Store started successfully
2016-08-18 18:36:20.928 INFO  QuartzScheduler:575 - Scheduler AntonJohanssonSchedulerInstance_$_fferreirapc-1.2.3-1471541780827 started.
2016-08-18 18:36:20.973 INFO  EntryPoint:92 - Press [Enter] at any time to stop...
2016-08-18 18:36:21.040 INFO  JobWrapper:19 - Executing
2016-08-18 18:36:30.940 INFO  JobWrapper:19 - Executing
2016-08-18 18:36:40.935 INFO  JobWrapper:19 - Executing
2016-08-18 18:36:50.935 INFO  JobWrapper:19 - Executing
</pre>