### PR TITLE
Make joda time a test scoped dependency 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,7 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>${joda.time.version}</version>
-        </dependency>
-    
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -103,6 +98,12 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
           <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda.time.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
+++ b/src/main/java/com/bikeemotion/quartz/jobstore/hazelcast/HazelcastJobStore.java
@@ -6,8 +6,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.ISet;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.query.Predicate;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.quartz.Calendar;
 import org.quartz.DateBuilder;
 import org.quartz.JobDetail;
@@ -55,7 +53,6 @@ import static com.bikeemotion.quartz.jobstore.hazelcast.TriggerState.toClassicTr
 import static com.bikeemotion.quartz.jobstore.hazelcast.TriggerWrapper.newTriggerWrapper;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static org.quartz.impl.matchers.StringMatcher.StringOperatorName.EQUALS;
 
 /**
  *
@@ -100,7 +97,6 @@ public class HazelcastJobStore implements JobStore, Serializable {
   private String instanceName;
   private boolean shutdownHazelcastOnShutdown = true;
 
-  public static final DateTimeFormatter FORMATTER = ISODateTimeFormat.basicDateTimeNoMillis();
 
   @Override
   public void initialize(ClassLoadHelper loadHelper, SchedulerSignaler signaler)


### PR DESCRIPTION
This might be a breaking change, bacause unused *public static* `FORMATTER` is deleted, but I do not see why joda-time needs to be on the class path.
Especially for java 8 one would favor java.time over joda-time.